### PR TITLE
Create Henry-Tibble-Vignette-Extension.Rmd

### DIFF
--- a/Henry-Tidyverse-Recipe_1.Rmd
+++ b/Henry-Tidyverse-Recipe_1.Rmd
@@ -1,0 +1,176 @@
+---
+title: "DATA607 Tidyverse Recipe 1"
+author: "Henry Otuadinma"
+date: "May 3, 2019"
+output:
+  html_document:
+    toc: true
+    theme: spacelab
+    highlight: tango
+    toc_float:
+      collapsed: false
+      smooth_scroll: true
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+### The `stringr` package
+
+## Overview
+
+The `stringr` package is a consistent, simple and easy to use set of wrappers that is built on top of the `stringi` package. The `stringi` package uses the ICU C library to provide fast, correct implementations of common string manipulations and provides a comprehensive set covering almost anything you can imagine, while `stringr` focusses on the most important and commonly used string manipulation functions.
+
+All functions in stringr start with `str_` and take a vector of strings as the first argument. One of the uses of this package that I enjoy a lot is in tidying up the output goten from webscrapping a webpage (using appropriate functions from the `tidyvest` package) to make the result presentable.
+
+Assuming I want to get some top selling books in a particular category like Law from Amazon, I can easily call some of the stringr functions like: 
+
+1). `str_replace_all`: to replace selected string pattern by another string or an empty one. The pattern can be matched with rejex
+
+2). `str_trim`: trims the beginning and end of a string
+
+3). `str_extract`: extracts a given string pattern from the lot. The pattern can be matched with rejext
+
+4). `str_split`: splits a string at a given character
+
+
+to tidy up the result. Each of these listed functions perform functions just as their names indicate.
+
+
+## Load libraries, read web page
+
+```{r}
+library(stringr)
+library(rvest)
+library(DT)
+```
+
+
+```{r}
+
+html_raw <- html_nodes(read_html('https://www.amazon.com/Best-Sellers-Books-Law/zgbs/books/10777/ref=zg_bs_nav_b_1_b', encoding = "en_US.UTF-8"), 'ol#zg-ordered-list')
+
+```
+
+
+### Tidy up the Result
+
+```{r}
+
+processNodes <- function(rawNode, genre)
+{
+    imgs <- vector()
+    genres <- vector()
+    titles <- vector()
+    authors <- vector()
+    ratings <- vector()
+    numRaters <- vector()
+    types <- vector()
+    prices <- vector()
+    
+    itemsRaw <-html_nodes(rawNode, 'span.zg-item')  # using html_nodes from rvest to extract the needed nodes
+  
+    for(i in 1: length(itemsRaw))
+    {
+        x <- itemsRaw[i]
+        xImg <- str_replace_all(str_extract(x, '(?<=src=)"(.+?)"'), '\"', '') # matching the image element's source attribute using a rejex pattern
+        
+        xTitle <- str_trim(str_replace_all(html_text(html_node(x, '.a-link-normal > div')), 
+                                           "[\r\n]" , ""), side='both') # combining str_trim, str_replace_all, html_text and html_node in one call to tidy a book's title
+        
+        if(str_detect(xTitle, ':') == TRUE)
+        {
+          xTitle <- str_split(xTitle, ':')[[1]][1] # Shorten the title by splitting at the colon (:)
+        }
+        
+        xAuthor <- str_trim(html_text(html_node(x, '.a-link-child')), side='both')
+        
+        if(is.na(xAuthor) || is.null(xAuthor))
+        {
+          xAuthor <- str_trim(html_text(html_node(x, 'span.a-color-base')), side='both')
+        }
+        
+        xRating <- str_trim(str_extract(html_node(x, '.a-icon-alt'), '\\d+(\\.\\d+)'), side='both')
+        
+        xNumRaters <- str_replace(str_trim(html_text(html_node(x, 'div.a-icon-row > a.a-size-small')), side='both'), ',', '')
+        
+        if(is.na(xNumRaters) || is.null(xNumRaters))
+        {
+          xNumRaters <- str_replace(str_trim(html_text(html_node(x, 
+                        'div.a-spacing-none > a-link-normal')), side='both'), ',', '')
+        }
+       
+        xType <- str_trim(html_text(html_node(x, 'div.a-size-small > span.a-color-secondary')), side='both')
+        
+        p <- str_extract(html_node(x, 'span.p13n-sc-price'), '\\d+(\\.\\d+)')
+        
+        xPrice <-  round(as.numeric(p), 2)
+        
+        if(is.na(xPrice) || is.null(xPrice))
+        {
+          xPrice <- str_extract(str_trim(html_text(html_node(x, 
+                        'span.a-color-price')), side='both'), '[[:alpha:] ]{2,}')
+        }
+        
+        imgs <- c(imgs, xImg)
+        genres <- c(genres, genre)
+        titles <- c(titles, xTitle)
+        authors <- c(authors, xAuthor)
+        ratings <- c(ratings, xRating)
+        numRaters <- c(numRaters, xNumRaters)
+        types <- c(types, xType)
+        prices <- c(prices, xPrice)
+    }
+    
+    return(data.frame(title = titles, author = authors, genre = genres, rating = ratings, img = imgs,
+                      numRater = numRaters, type = types, price = prices))
+}
+
+```
+
+
+##### This Returns a dataframe with the cleaned observations
+ 
+
+```{r, warning=FALSE, message=FALSE}
+
+law_books <- processNodes(html_raw, 'Law')
+
+```
+
+
+### Show the output
+
+```{r}
+
+law_books_filtered <- subset(law_books, select=c(title, author, genre, rating, numRater, type, price)) #Remove the book image url
+
+datatable(law_books_filtered, colnames= c("Title", "Author", "Genre", "Rating", "Number of reviewers", "Type", "Price($)"), class = 'cell-border stripe', options = list(
+  initComplete = JS(
+    "function(settings, json) {",
+    "$(this.api().table().header()).css({'background-color': '#1f77b4', 'color': '#fff', 'text-align': 'center !important'});",
+    "$(this.api().table().body()).css({'color': '#000', 'text-align': 'center !important'});",
+    "}")
+))
+
+```
+
+
+##### Exporting the tidied data to a csv file for further analyses
+
+```{r}
+
+write.csv(law_books_filtered, "top_selling_law_books.csv", row.names=FALSE)
+
+```
+
+
+### Conclusion
+
+The `stringr` package is very useful when it comes to cleaning data mined from different sources and manipulating already available data sets. This recipe has demonstrated the use of some of its functions in data cleaning and manipulation. However, this is not exhaustive.
+
+
+### References
+
+<a href="https://www.rdocumentation.org/packages/stringr/versions/1.4.0">stringr</a>


### PR DESCRIPTION
---
title: "Tibble Vignette"
author: "Austin Chan"
date: "April 18, 2019"
output: 
  html_document:
    theme: cosmo
    toc: true
    toc_float: true
---

##Introduction

Dataframes have been fundamental to R as its preferred way to store data in a straightforward and human-readable form. For the most part, dataframes do their job well; they can store data of different types in the same dataframe, they can be subsetted relatively easily, and they interact cleanly with other objects in R. However, as data science has evolved, some functionality of dataframes has become inconvenient and inefficient. This includes default behavior like `stringsAsFactors = TRUE`, printing every row and column when calling the dataframe, and partial column matching. These "features" often lead to long function calls, unintentionally printing an entire dataframe, and calling the wrong columns, which create errors and frustration. Given that dataframes are used so frequently in R, these inconveniences and inefficiencies can snowball over time leading to poor performance overall. Tibbles are the solution to these problems.

###What is a tibble?

Simply put, a tibble is a lightweight data frame that removes the annoying default behaviors of dataframes, while still preserving core functionality. Tibbles are designed to be more restrictive than dataframes to encourage users into writing less sloppy code. Tibbles can do everything dataframes can do (barring a few niche exceptions) faster and with less overhead. Let's get into some examples.

###Installing `tibble`

Tibble can be installed like any other package in R using the `install.packages()` function. There are multiple sources for the `tibble` package including CRAN, the tidyverse, and Github. The tibble package is frequently maintained and easily accessible, which is nice. The following code installs the `tibble` package from various different sources according to your preference.

```{r,eval = FALSE}
#Install tibble directly from CRAN
install.packages("tibble")

#Install tibble through the tidyverse package
install.packages("tidyverse")

#Install tibble through Github
devtools::install_github("tidyverse/tibble")
```

###Data

I will be using the women in STEM dataset from fivethirtyeight's Github to show some examples of `tibble`. The link to the data is here:

https://github.com/fivethirtyeight/data/blob/master/college-majors/women-stem.csv

This data contains information about women in various STEM fields, like the proportion of women in the field and the median income of the field. This data was used for an article about picking a college major from an economic perspective. The link to the article is here:

https://fivethirtyeight.com/features/the-economic-guide-to-picking-a-college-major/


The data can be seen below as a tibble:


```{r}
library(tibble)
library(readr)

women_stem_tibble =  read_csv("https://raw.githubusercontent.com/fivethirtyeight/data/master/college-majors/women-stem.csv")

women_stem_tibble
```

##Tibbles vs. Data Frames

As specified in the introduction, tibbles are lightweight dataframes with different default behaviors. There are a few characteristics that separate tibbles from dataframes:

- Tibbles preview only the first few rows when called.
- Tibbles do not change input data types.
- Tibbles do not change variable names.
- Tibbles do not use row names.
- Tibbles only recycles single element vectors.

It is important to remember that tibbles are designed to be more restrictive than dataframes to prevent common bugs that can occur when using dataframes. The following sections will provide examples of the differing characteristics and how these differences can be useful.

###Data previewing

When loading data, most people try to look at a preview of their data to see if their data appears correct at a glance. This process usually involves fetching the first few rows of the data and checking it for major issues. The typical call for this type of operation is `head(dataframe)`, where the `head()` function fetches the first few rows from `dataframe`. The reason `head()` needs to be called is because dataframes print the entire dataframe when they are called without the `head()` function. This "feature" can be seen below:

Notice how long and disorienting the data can appear when called this way.

```{r}
women_stem_df = read.csv("https://raw.githubusercontent.com/fivethirtyeight/data/master/college-majors/women-stem.csv")

women_stem_df
```

Unlike dataframes, tibbles have built-in data preview functionality. When tibbles are called, they only show the first few rows of the data instead of the entire dataset.

```{r}
women_stem_tibble
```

###Input data types

One quirk of dataframes is that they change strings to the factor data type automatically. This used to be a convenience feature when data was simpler and string vectors were almost always categorical variables. This would come in handy with columns with predefined categories like gender, where the vector would only contain the values "male", "female", and "other". However, with the increasing popularity of natural language processing and using words as data, it is much more convenient to keep string vectors as strings rather than to change them to factors.

Unlike dataframes, tibbles do not change strings to the factor data type automatically. Instead, tibbles preserve the input data type by default. This quirk can be seen below. Notice that the `Major` column is a 76-level factor in the dataframe, while the same column is a character data type in the tibble.

```{r}
str(women_stem_df$Major)

str(women_stem_tibble$Major)
```

###Variable names

Another weird quirk of dataframes is that they don't like spaces in their column names. As a result, dataframes will change spaces in column names to periods. The reason dataframes do this is because referencing columns that had spaces without autocomplete was very annoying due to having to put quotes around the column name to reference it. However, now with the modern version of R, tab completion is a default feature, making column references very simple.

```{r}
nwsdf = data.frame("name with spaces" = 2)
nwsdf
nwsdf$name.with.spaces
```

```{r}
nwst = tibble("name with spaces" = 2)
nwst
nwst$`name with spaces`
```

###Row names

In order to maintain simplicity, tibbles cannot use row names. Since row names are special attributes that are stored differently from normal columns, they can complicate dataframes by adding special attributes that were not designedd to store long names. If `row.names` is called on a tibble, it will return the index of the rows. 

```{r}
row.names(women_stem_tibble)
```

###Recycling

One unique characteristic of R is its use of element recycling. Recycling is when elements are reused when a vector does not have enough elements to match the length of another vector it is attached to. An example of recycling can be seen below.

In the example below, the 1 in the x column is recycled 10 times to match the 10 elements in the y column.

```{r}
tibble(x = 1, y = 1:10)
```

Recycling can be useful if the user is lazy and does not want to call the `rep()` function every time they want to repeat a number to the same length as another vector.

Recycling can also be used for vectors with multiple elements as seen below. However, the catch is that the vectors must be multiples/divisors of each other in order to recycle multiple elements. Notice that x is 1:4 recycled once (total length 8), while y is printed normal (total length 8).

```{r}
data.frame(x = 1:4, y = 1:8)
```

If the vector is not a multiple/divisor of the other vector, it will not recycle properly and throw an error. This error happens frequently for people who use recycling and it can cause many problems.

```{r,error = TRUE}
data.frame(x = 1:3, y = 1:8)
```

Tibbles circumvent this muiltiple element recycling problem by only allowing vectors of length 1 to be recycled. This minimizes the possible errors that can occur when recycling because length 1 vectors can always be recycled.

```{r,error=TRUE}
tibble(x = 1:4, y = 1:8)
```


## Extension by Henry Otuadinma

##### Austin already did a great job on this, I am going to add a little more to what he already has by demonstrating the use of `glimpse`, and `as_tibble` functions of the tibble package.


##### `glimpse` is simply getting a glimpse of the data. According to the documentation, it is like a transposed version of `print` such that columns run down the page, and data runs across. This makes it possible to see every column in a data frame. It's a little like the `str` function applied to a data frame but it tries to show you as much data as possible. (And it always shows the underlying data, even when applied to a remote data source.)

```{r}
glimpse(women_stem_tibble)

```

##### `as_tibble` Coerces Lists and Matrices to Data Frames. The `as.data.frame` is effectively a thin wrapper around `data.frame`, and hence is rather slow (because it calls data.frame() on each element before cbinding together). But `as_tibble` is a new S3 generic with more efficient methods for matrices and data frames.

```{r}
m <- matrix(rnorm(50), ncol = 5)
colnames(m) <- c("a", "b", "c", "d", "e")
df <- as_tibble(m)
df
```


##Conclusion

Tibbles are a very useful form of dataframe that is fast and lightweight. Instead of using the bloated and outdated features of dataframes, tibbles offer a simplified version that preserves core functionality while removing features that are prone to errors and inefficiency like row names, previewing the entire dataframe, and multiple element recycling. Tibbles are especially useful for string data because they do not change column names or column data types for strings. 

Overall, tibbles are can do almost everything dataframes can do while being faster, more efficient, and more convenient.

